### PR TITLE
feat: include user-specified files in the head tag

### DIFF
--- a/_includes/default/head.liquid
+++ b/_includes/default/head.liquid
@@ -73,4 +73,9 @@
     <meta name="twitter:card" content="{% unless page.thumbnail %}summary{% else %}summary_large_image{% endunless %}">
     <meta name="twitter:image" content="{{ '/' | absolute_url }}{% if page.thumbnail %}{{ page.thumbnail }}{% else %}{{ page.feature-img | default: site.header_feature_image }}{% endif %}">
     <meta name="twitter:image:alt" content="{{ page.title | default: site.title }}">
+
+    <!-- Custom -->
+    {% if site.data.head.include %}
+    {% include {{ site.data.head.include }} %}
+    {% endif %}
 </head>


### PR DESCRIPTION
`<head>` にサイト側で追加のデータを指定できるように `site.data.head.include` で指定したファイルを include するように機能を追加しました。

主な用途は別ドメインで検証用に NekoBlocker のサイトを公開したときに `noindex, nofollow` を指定して検索エンジンにインデックスされないようにすることです。
